### PR TITLE
Meteor: Allow blade views to be included anywhere inside a meteor project

### DIFF
--- a/meteor/package.js
+++ b/meteor/package.js
@@ -44,8 +44,15 @@ Package.register_extension("blade", function(bundle, srcPath, servePath, where) 
 	//The template name does not contain ".blade" file extension or a beginning "/"
 	var templateName = path.dirname(servePath).substr(1);
 	templateName += (templateName.length > 0 ? "/" : "") + path.basename(servePath, ".blade");
-	//Remove directory prefix
-	templateName = templateName.substr(templateName.lastIndexOf("/") + 1);
+	//Templates are assumed to be stored in "views/" or "client/views/"
+	//so remove this from the name, if needed
+	if(templateName.substr(0, 6) == "views/")
+		templateName = templateName.substr(6);
+	else if(templateName.substr(0, 13) == "client/views/")
+		templateName = templateName.substr(13);
+	//Remove directory prefix if not in views/ or client/views/
+	else
+		templateName = templateName.substr(templateName.lastIndexOf("/") + 1);
 	//Finally, tell the Blade compiler where these views are stored, so that file includes work.
 	//The location of meteor project = srcPath.substr(0, srcPath.length - servePath.length)
 	var basedir = srcPath.substr(0, srcPath.length - servePath.length);

--- a/meteor/runtime-meteor.js
+++ b/meteor/runtime-meteor.js
@@ -29,8 +29,14 @@
 		blade._includeInfo = info;
 		//Get the name of the included Template
 		var name = resolveFilename(info.rel + "/" + relFilename);
-		//Remove directory prefix
-		name = name.substr(name.lastIndexOf("/") + 1);
+		//Remove views/ or client/views/ prefix
+		if(name.substr(0, 6) == "views/")
+			name = name.substr(6);
+		else if(name.substr(0, 13) == "client/views/")
+			name = name.substr(13);
+		//Remove directory prefix if not in views/ or client/views/
+		else
+			name = name.substr(name.lastIndexOf("/") + 1);
 		//Remove .blade file extension
 		if(name.substr(-6) == ".blade")
 			name = name.substr(0, name.length - 6);


### PR DESCRIPTION
I've slightly modified the meteor code to no longer require templates to be located in `views/` or `client/views/`. I did this because I don't like organizing my Meteor project files by filetype. I prefer to place my files into folders for each site feature (each with one .coffee / .js, one .blade / .html, and one .styl / .css file, plus folders for sub-features if necessary).

Note: I was originally putting my `body.blade` file in `client/base/`. However, reactive binding in templates was not working until I moved it directly inside either `client/`, `views/`, `client/views/`, or the project's base directory. Not really sure how that works, but it seems to be working for my purposes.

Edit: I put the original code back in for templates in `views/` or `client/views/` for any projects that may be dependent on the funky namespacing system used for subdirectories of those folders. Any views placed outside of these folders are not namespaced and can be accessed directly as properties of `Template`.
