### PR TITLE
Always catch runtime errors

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -105,8 +105,7 @@ Compiler.prototype.compile = function(cb) {
 		//Only include error handling and source code, if needed
 		if(this.options.minify !== true && this.options.includeSource)
 			this._pushOff(ns + '.source = ' + JSON.stringify(this.string) + ";");
-		if(this.options.minify !== true)
-			this._pushOff("\ntry {");
+		this._pushOff("\ntry {");
 		//Now compile the template
 		this._pushOff('with(' + ns + '.locals) {');
 		for(var i = 0; i < this.ast.doctypes.length; i++)
@@ -118,6 +117,8 @@ Compiler.prototype.compile = function(cb) {
 		//Close main `try` and insert `catch`
 		if(this.options.minify !== true)
 			this._pushOff("} catch(e){return cb(" + ns + ".r.rethrow(e, " + ns + ") );}");
+		else
+		  this._pushOff("} catch(e){return cb(e);}");
 		//End of template callback
 		this._pushOff('if(!' + ns + '.inc) ' + ns + '.r.done(' + ns + ');');
 		if(this.blockDeclarations)


### PR DESCRIPTION
I noticed that my express app would crash when minify was set to true (and a template had a runtime error) instead of allowing me the chance to serve a nicely formatted 500. Does catching / not catching runtime errors have something to do with minification? I am assuming runtime.rethrow was affected as you can see in my pull request.

Also, the minify option was set for the middleware - it seems maybe confusing to me that these options also affect express's view engine (server-side rendering), so maybe there is a separate issue there?
