### PR TITLE
Fixed error when working with prototypes

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -236,6 +236,11 @@ Compiler.prototype._compileNode = function(node) {
 	{
 		case 'tag':
 			var attrs = node.attributes;
+			
+			// delete all attributes that have no / an empty name
+			for (var name in attrs)
+				if (!name) delete attrs[name];
+			
 			//id attribute
 			if(node.id)
 			{


### PR DESCRIPTION
Upon rendering any template, as long as it contains an element that has attributes, blade throws the error:
"Unable to read property text of undefined"
It turned out, that, when working with prototypes, blade appends an attribute called '' with the value ```undefined``` to the attribute list. Using the above fix, such attributes get removed from the attribute list before getting compiled, and the error does not occur.

This is only a workaround. I looked into the "lib/parser/index.js"-file, but couldn't find the line where the attributes are generated.