### PR TITLE
Locked down 'pegjs' and 'uglify-js' dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
 	"dependencies": {
 	},
 	"devDependencies": {
-		"pegjs": ">=0.7",
-		"uglify-js": ">=2.2.3 || >=1.2 <2"
+		"pegjs": "^0.7.0",
+		"uglify-js": "^2.2.3 || >=1.2 <2"
 	},
 	"optionalDependencies": {
-		"uglify-js": ">=2.2.3 || >=1.2 <2",
+		"uglify-js": "^2.2.3 || >=1.2 <2",
 		"commander": ">=0.6"
 	},
 	"engines": {


### PR DESCRIPTION
Hey Blake,

I noticed `uglify-js` v3 was just released, which includes [breaking changes](https://github.com/mishoo/UglifyJS2#note).
I didn't look through the changes, but they broke the middleware serving `/blade/blade.js`, as well as `tmpl.toString()`, which now returns `undefined`:

```js
blade._cachedViews["IDE.blade"]=undefined;var e=blade._cb["IDE.blade"];e&&e(null,".",[],false);
```

While creating the fork to specify the `uglify-js` version number, I found that `pegjs` removed the `--track-line-and-column` option in version [0.8.0](https://github.com/pegjs/pegjs/blob/master/CHANGELOG.md#080) (4th item in the [big changes](https://github.com/pegjs/pegjs/blob/master/CHANGELOG.md#big-changes)), so I locked `pegjs` down as well.

I converted your version numbers from greater-than `>=2.2.3` to caret syntax (`^2.2.3`).  I can convert them back to version ranges if they were specified with greater-than for a reason, or if you just prefer that syntax.

Thanks,
Ryan